### PR TITLE
Create the destination directory before extracting to it

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -7,9 +7,11 @@ end
 action :extract do
   install_rubyzip_gem
   converge_by "Extracting #{new_resource.from} into #{new_resource.into}" do
+    require 'fileutils'
     ::Zip::File.open(new_resource.from) do |zip|
       zip.each do |zipentry|
         destination = ::File.join(new_resource.into, zipentry.name)
+        FileUtils.mkdir_p(File.dirname(destination))
         zip.extract(zipentry, destination)
       end
     end


### PR DESCRIPTION
Currently this can fail while attempting to extract a file if the directory it should be extracted to doesn't exist.

Most of the examples I have seen of extracting an archive using rubyzip include the `mkdir_p` step to prevent against this.